### PR TITLE
Give a name for ExMQTT process

### DIFF
--- a/lib/exmqtt.ex
+++ b/lib/exmqtt.ex
@@ -97,7 +97,7 @@ defmodule ExMQTT do
   """
   @spec start_link(opts) :: {:ok, pid}
   def start_link(opts) do
-    GenServer.start_link(__MODULE__, opts)
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
   end
 
   ## Async


### PR DESCRIPTION
Fix the `GenServer.cast(__MODULE__, request)` error, as the module name is not registered as a process name